### PR TITLE
Fix typo in subathon widget when a Tier 3 sub is received

### DIFF
--- a/subathon/widget-main.js
+++ b/subathon/widget-main.js
@@ -219,7 +219,7 @@ window.widget.serviceModules.registerServiceModuleProvider({
               if (isInt(str) && managedData.timeAdditions.t2[0]) addTime(parseInt(str, 10));
               break;
             case "3000":
-              str = managedData.timeAdditions.t2[1];
+              str = managedData.timeAdditions.t3[1];
               if (isInt(str) && managedData.timeAdditions.t3[0]) addTime(parseInt(str, 10));
               break;
           }


### PR DESCRIPTION
The time being added was the one configured for Tier 2 subs, but it should add the time configured for Tier 3 subs.