### PR TITLE
Use communityGiftPurchase Activity to add time from bulk gifts

### DIFF
--- a/subathon/widget-main.js
+++ b/subathon/widget-main.js
@@ -205,8 +205,27 @@ window.widget.serviceModules.registerServiceModuleProvider({
       let str = "";
       // Update subathon end timestamp
       switch (activity.type) {
+        case 'communityGiftPurchase':
+          switch (activity.data.tier) {
+            case "1000":
+              str = managedData.timeAdditions.t1[1];
+              if (isInt(str) && managedData.timeAdditions.t1[0]) addTime(parseInt(str, 10) * activity.data.amount);
+              break;
+            case "2000":
+              str = managedData.timeAdditions.t2[1];
+              if (isInt(str) && managedData.timeAdditions.t2[0]) addTime(parseInt(str, 10) * activity.data.amount);
+              break;
+            case "3000":
+              str = managedData.timeAdditions.t3[1];
+              if (isInt(str) && managedData.timeAdditions.t3[0]) addTime(parseInt(str, 10) * activity.data.amount);
+              break;
+          }
+          break;
         case 'subscriber':
           if (activity.bulkGifted) { // Ignore gifting event and count only real subs
+            return;
+          }
+          if (activity.activityGroup) { // Ignore community gifted subs because we used the communityGiftPurchase Activity to add time for these
             return;
           }
           switch (activity.data.tier) {


### PR DESCRIPTION
Fixes https://github.com/StreamElements/elements-sdk-examples/issues/5

This fix relies on my working theory that subscriber events are being sent too quickly to be processed after a bulk community sub gift event, and some are being dropped. Instead, it uses the communityGiftPurchase Activity to add the correct amount of time.

This is a draft PR because it is entirely UNTESTED - largely because I can't find a VS Code extension that actually supports the requirements listed in https://dev.streamelements.com/docs/widgets-elements-sdk/bult8ogswaeu2-setup-guide (the instructions that the article suggests do not work).

If anyone knows of an extension that actually supports both CORS and CSP - or, really, any working instructions for setting up a dev environment for the Elements SDK - please let me know and I will test this properly.